### PR TITLE
Google Translate API 開始收費了

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source :gemcutter
+
+# Specify your gem's dependencies in techbang-authentication.gemspec
+gemspec
+
+gem "easy_translate"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+PATH
+  remote: .
+  specs:
+    chinese_permalink (1.1.3)
+      easy_translate
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    easy_translate (0.2.1)
+      json
+    json (1.5.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  chinese_permalink!
+  easy_translate

--- a/chinese_permalink.gemspec
+++ b/chinese_permalink.gemspec
@@ -43,12 +43,12 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<sishen-rtranslate>, [">= 0"])
+      s.add_runtime_dependency(%q<easy_translate>, [">= 0"])
     else
-      s.add_dependency(%q<sishen-rtranslate>, [">= 0"])
+      s.add_dependency(%q<easy_translate>, [">= 0"])
     end
   else
-    s.add_dependency(%q<sishen-rtranslate>, [">= 0"])
+    s.add_dependency(%q<easy_translate>, [">= 0"])
   end
 end
 

--- a/lib/chinese_permalink.rb
+++ b/lib/chinese_permalink.rb
@@ -9,7 +9,7 @@ module ChinesePermalink
 
   def self.included(base)
     base.class_eval do
-      class_inheritable_accessor :permalink_attrs, :permalink_field, :before_methods, :after_methods
+      class_attribute :permalink_attrs, :permalink_field, :before_methods, :after_methods
     end
     base.extend ClassMethods
   end 

--- a/lib/chinese_permalink.rb
+++ b/lib/chinese_permalink.rb
@@ -1,8 +1,8 @@
 begin
   # rtranslate is a gem that can translate text based on google translate
-  require 'rtranslate'
+  require 'easy_translate'
 rescue Object
-  puts "no rtranslate, you might want to look into it."
+  puts "no easy_translate, you might want to look into it."
 end
 
 module ChinesePermalink
@@ -24,7 +24,7 @@ module ChinesePermalink
         chinese_permalink = self.send(method, chinese_permalink)
       end
 
-      english_permalink = Translate.t(chinese_permalink, 'CHINESE', 'ENGLISH')
+      english_permalink = EasyTranslate.translate(chinese_permalink, :from => 'zh-TW', :to => :en )
       self.class.after_methods.each do |method|
         english_permalink = self.send(method, english_permalink)
       end


### PR DESCRIPTION
Hi, Google Translate API 開始收費了。而且 v1 也即將被 deprecated 掉了。

所以我將之換成支援 support v2 的 EasyTranslate。

且 EasyTranslate 可以設定 API key
