### PR TITLE
Transition to Microsoft Translator on Azure Marketplace

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -14,14 +14,19 @@ h2. Install
 
 ***************************************************************************
 
-h2. Config
+h2. Setup
 
-As google translator api begins to charge, I decide to use bing translator api, it's free. You have to add a config file to tell chinese_permalink what's your bing app id in <code>config/chinese_permalink.yml</code>
+As google translator api begins to charge, I decide to use bing translator api, it's free.
+
+First, subscribe to "Microsoft Translator":https://datamarket.azure.com/dataset/bing/microsofttranslator on Windows Azure Marketplace.
+
+Then, fill your Marketplace application info in <code>config/chinese_permalink.yml</code>. You can create an app on "Marketplace Developer":https://datamarket.azure.com/developer/applications page.
 
 <pre><code>
 bing:
-  app_id: xxx
-  language: zh-cht (chinese traditional, default is zh-chs, chinese simplified)
+  client_id: APP_CLIENT_ID
+  client_secret: APP_CLIENT_SECRET
+  language: zh-cht # (chinese traditional, default is zh-chs, chinese simplified)
 </code></pre>
 
 ***************************************************************************

--- a/chinese_permalink.gemspec
+++ b/chinese_permalink.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = "1.8.10"
   s.summary = "This plugin adds a capability for AR model to create a seo permalink with your chinese text."
+  s.add_dependency('bing_translator', '~> 3.0.0')
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
[Microsoft Translator](https://datamarket.azure.com/dataset/bing/microsofttranslator) is now available on Azure Marketplace, and the [original Translator Developer Page](http://www.microsofttranslator.com/dev/) also promotes the new Azure Marketplace application, although the old API is still working (which chinese_permalink gem uses today.)

The new API from Marketplace must be authorized via OAuth, and an access_token will be expired in a certain time, thus the library must take care about re-authorization. I found a gem `bing_translator` ([CodeBlock/bing_translator-gem](https://github.com/CodeBlock/bing_translator-gem)) that can deal with authorization and take care about expired access_token.

The biggest difference is that config file `config/chinese_permalink.yml` must be modified because it needs client ID and client secret for authorization. Currently there is only AppID required, which is no longer required either. Example:

``` yaml
bing:
  client_id: XXXXXXXXXX
  client_secret: XXXXXXXXXX
  language: zh-cht # from which language
```

p.s. I can't even run `rake test` in current version, so I'm not sure if these changes pass unit tests, but it's been tested with one of our products and seems working.

See also:
- [Microsoft Translator API - Frequently Asked Questions](http://social.msdn.microsoft.com/Forums/en-US/microsofttranslator/thread/c71aeddd-cc90-4228-93cc-51fb969fde09) (including migration guide)
